### PR TITLE
Use Addressable::URI#hostname instead of Addressable::URI#host

### DIFF
--- a/lib/reverse_proxy/client.rb
+++ b/lib/reverse_proxy/client.rb
@@ -79,7 +79,7 @@ module ReverseProxy
       target_request['Accept-Encoding'] = nil
 
       # Make the request
-      Net::HTTP.start(uri.host, uri.port, use_ssl: (uri.scheme == "https")) do |http|
+      Net::HTTP.start(uri.hostname, uri.port, use_ssl: (uri.scheme == "https")) do |http|
         target_response = http.request(target_request)
       end
 


### PR DESCRIPTION
## Problem
When use the url that wrote direct IPv6, It cause error: `SocketError: getaddrinfo: Name or service not known`

## A way to solve
Use Addressable::URI#hostname instead of Addressable::URI#host.
See: http://www.rubydoc.info/gems/addressable/Addressable/URI:hostname

```ruby
2.2.1 :015 > Addressable::URI.parse('http://[2001:200:0:889c:216:3eff:fe75:99ca]/').host
=> "[2001:200:0:889c:216:3eff:fe75:99ca]" 
2.2.1 :016 > Addressable::URI.parse('http://[2001:200:0:889c:216:3eff:fe75:99ca]/').hostname
=> "2001:200:0:889c:216:3eff:fe75:99ca" 
2.2.1 :017 > Addressable::URI.parse('http://www.nttv6.jp/').host
=> "www.nttv6.jp" 
2.2.1 :018 > Addressable::URI.parse('http://www.nttv6.jp/').hostname
=> "www.nttv6.jp"
```