### PR TITLE
Replace the parsing cookie logic instead of cookiejar gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gem 'rails'
 gem 'rack'
 gem 'rack-proxy'
 gem 'addressable'
-gem 'cookiejar', '~> 0.3.2'
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,6 @@ GEM
     addressable (2.3.8)
     arel (6.0.0)
     builder (3.2.2)
-    cookiejar (0.3.2)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     docile (1.1.5)
@@ -149,7 +148,6 @@ PLATFORMS
 DEPENDENCIES
   addressable
   bundler (~> 1.0)
-  cookiejar (~> 0.3.2)
   jeweler (~> 2.0.1)
   rack
   rack-proxy
@@ -157,3 +155,6 @@ DEPENDENCIES
   rdoc (~> 3.12)
   shoulda
   simplecov
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
# Purpose
CookieJar gem is not support max-age attributes in cookies, and not maintained for a long time.
Related issue: https://github.com/axsuul/rails-reverse-proxy/issues/2

# Changes
- Removed CookieJar gem
- Implemented the cookie parsing logic into this gem
  - Renamed `expires_at` to `expires`
  - Renamed `http_only` to `httponly`
  - Both changes are according to implementation of ActionDispatch::Cookies
    http://api.rubyonrails.org/classes/ActionDispatch/Cookies.html

Any thoughts?