### PR TITLE
Fixing Rails 5.1 warnings

### DIFF
--- a/lib/reverse_proxy/controller.rb
+++ b/lib/reverse_proxy/controller.rb
@@ -49,14 +49,14 @@ module ReverseProxy
           if content_type and content_type.match /image/
             send_data body, content_type: content_type, disposition: "inline", status: code
           else
-            render text: body, content_type: content_type, status: code
+            render body: body, content_type: content_type, status: code
           end
         end
 
         yield(config) if block_given?
       end
 
-      client.request(env, options)
+      client.request(request.env, options)
     end
   end
 end


### PR DESCRIPTION
Fixing the two warnings listed bellow:
 - DEPRECATION WARNING: env is deprecated and will be removed from Rails 5.1
 - DEPRECATION WARNING: `render :text` is deprecated because it does not
 actually render a `text/plain` response. Switch to `render plain: 'plain
 text'` to render as `text/plain`, `render html: '<strong>HTML</strong>'` to
 render as `text/html`, or `render body: 'raw'` to match the deprecated
 behavior and render with the default Content-Type, which is `text/plain`.