### PR TITLE
add on_start callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ class WordpressController < ApplicationController
 
       # There's also other callbacks:
       # - on_set_cookies
+      # - on_connect
       # - on_response
       # - on_set_cookies
       # - on_success

--- a/lib/reverse_proxy/client.rb
+++ b/lib/reverse_proxy/client.rb
@@ -7,6 +7,7 @@ module ReverseProxy
     @@callback_methods = [
       :on_response,
       :on_set_cookies,
+      :on_connect,
       :on_success,
       :on_redirect,
       :on_missing,
@@ -87,6 +88,7 @@ module ReverseProxy
 
       # Make the request
       Net::HTTP.start(uri.hostname, uri.port, http_options) do |http|
+        callbacks[:on_connect].call(http)
         target_response = http.request(target_request)
       end
 


### PR DESCRIPTION
I had a situation where I needed to know if the proxy connection had successfully established, so that a particular fallback situation could occur depending on whether the request had been sent or whether the timeout happened before the connection/negotiation.

A new `on_start` callback made it easy to accomplish this.