### PR TITLE
Add option to pass through compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,6 @@ If you'd like to bypass SSL verification
 reverse_proxy "http://localhost:8000", verify_ssl: false
 ```
 
-If you'd like to allow the proxy to request compressed resources by forwarding the `Accept-Encoding` header
-
-```ruby
-reverse_proxy "http://localhost:8000", compression: :passthrough
-# Note that your controller's response will only be compressed
-# if the original response from localhost:8000 is compressed!
-```
-
 If you'd like to customize the options passed into the [HTTP session](https://ruby-doc.org/stdlib-2.4.0/libdoc/net/http/rdoc/Net/HTTP.html#start-method)
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ If you'd like to bypass SSL verification
 reverse_proxy "http://localhost:8000", verify_ssl: false
 ```
 
+If you'd like to allow the proxy to request compressed resources by forwarding the `Accept-Encoding` header
+
+```ruby
+reverse_proxy "http://localhost:8000", compression: :passthrough
+# Note that your controller's response will only be compressed
+# if the original response from localhost:8000 is compressed!
+```
+
 If you'd like to customize the options passed into the [HTTP session](https://ruby-doc.org/stdlib-2.4.0/libdoc/net/http/rdoc/Net/HTTP.html#start-method)
 
 ```ruby

--- a/lib/reverse_proxy/client.rb
+++ b/lib/reverse_proxy/client.rb
@@ -51,13 +51,11 @@ module ReverseProxy
       # We can pass in a custom path
       uri = Addressable::URI.parse("#{url}#{options[:path] || env['ORIGINAL_FULLPATH']}")
 
-      # Initialize request
-      target_request = Net::HTTP.const_get(source_request.request_method.capitalize).new(uri.request_uri)
-
-      # Setup headers
+      # Define headers
       target_request_headers = extract_http_request_headers(source_request.env).merge(options[:headers])
 
-      target_request.initialize_http_header(target_request_headers)
+      # Initialize request
+      target_request = Net::HTTP.const_get(source_request.request_method.capitalize).new(uri.request_uri, target_request_headers)
 
       # Basic auth
       target_request.basic_auth(options[:username], options[:password]) if options[:username] and options[:password]

--- a/lib/reverse_proxy/client.rb
+++ b/lib/reverse_proxy/client.rb
@@ -38,13 +38,13 @@ module ReverseProxy
 
     def request(env, options = {}, &block)
       options.reverse_merge!(
-        headers:     {},
-        http:        {},
-        path:        nil,
-        username:    nil,
-        password:    nil,
-        verify_ssl:  true,
-        compression: :disabled
+        headers:               {},
+        http:                  {},
+        path:                  nil,
+        username:              nil,
+        password:              nil,
+        verify_ssl:            true,
+        reset_accept_encoding: false
       )
 
       source_request = Rack::Request.new(env)
@@ -74,12 +74,9 @@ module ReverseProxy
       # Hold the response here
       target_response = nil
 
-      case options[:compression]
-      when :passthrough
-        # Pass along the "Accept-Encoding" header from the source request as-is,
-        # so we don't need to change anything
-      when :disabled, false, nil
-        # Remove the "Accept-Encoding" header if compression is disabled
+      if options[:reset_accept_encoding]
+        # Clear the "Accept-Encoding" header (which will
+        # disable compression or other server-side encodings)
         target_request['Accept-Encoding'] = nil
       end
 


### PR DESCRIPTION
We are using `rails-reverse-proxy` in front of a small server that serves static compressed assets. Eventually we noticed that assets were always being served uncompressed, and after some digging, I came across the spot where the `Accept-Encoding` header is stripped from proxied requests.

This PR adds a new `:compression` option to control how `rails-reverse-proxy` handles the `Accept-Encoding` header. `:disabled` (default) disables all compression, just like `rails-reverse-proxy` does today. `:passthrough` forwards the `Accept-Encoding` header, which will then allow the proxied server to return compressed responses (but it does _not_ compress uncompressed proxy responses). A future PR could add another option to allow uncompressed responses to be compressed by `rails-reverse-proxy`, but I decided not to add it to this PR since we didn't need it for our server.

---

Also, I don't have any experience working with Varnish, so I can't say for certain if `compression: :passthrough` would still cause Varnish to error out (like the previous comment in the code suggests), so hopefully someone else can chime in on that.

I will say I found some really weird behavior with Rack and the `Accept-Encoding` header. Previously, proxied request headers were set with [`Net::HTTPRequest#initialize_http_header`](http://ruby-doc.org/stdlib-1.9.2/libdoc/net/http/rdoc/Net/HTTPHeader.html#method-i-initialize_http_header), but for some reason, it looked like Rack would ignore the `Accept-Encoding` header? I'm not sure if that was because the version of Rack we were using, our version of Rails, or some other dependency... but I found that removing `#initialize_http_header` and using [`HTTPRequest::new`](https://ruby-doc.org/stdlib-2.1.1/libdoc/net/http/rdoc/Net/HTTPRequest.html#method-c-new) to set the header instead seemed to fix it. I wonder if the issue with Varnish was caused by this same issue as well...