### PR TITLE
Don't copy HTTP_VERSION from the source to the target request

### DIFF
--- a/lib/reverse_proxy/client.rb
+++ b/lib/reverse_proxy/client.rb
@@ -131,7 +131,7 @@ module ReverseProxy
 
     def extract_http_request_headers(env)
       headers = env.reject do |k, v|
-        !(/^HTTP_[A-Z_]+$/ === k) || v.nil?
+        !(/^HTTP_[A-Z_]+$/ === k) || k == "HTTP_VERSION" || v.nil?
       end.map do |k, v|
         [reconstruct_header_name(k), v]
       end.inject(Rack::Utils::HeaderHash.new) do |hash, k_v|


### PR DESCRIPTION
Although the HTTP Version appears as a header inside `env`, it's not actually a regular header. When `extract_http_request_headers` is called, it translates the `HTTP_VERSION` "header" into a `Version` header. `Version` is only a provisionally-supported header name, and is semantically meant to represent the version of an (evolving object)[https://www.w3.org/Protocols/HTTP/Object_Headers.html#z13]. It's not correct to pass the HTTP Version as the contents of the `Version` header, so this change skips the processing of that particular header entirely.