### PR TITLE
Remove rails dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source "http://rubygems.org"
 
 gem 'actionpack'
-gem 'rack'
-gem 'rack-proxy'
 gem 'addressable'
 
 # Add dependencies to develop your gem here.

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem 'rails'
+gem 'actionpack'
 gem 'rack'
 gem 'rack-proxy'
 gem 'addressable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,6 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    actionmailer (4.2.1)
-      actionpack (= 4.2.1)
-      actionview (= 4.2.1)
-      activejob (= 4.2.1)
-      mail (~> 2.5, >= 2.5.4)
-      rails-dom-testing (~> 1.0, >= 1.0.5)
     actionpack (4.2.1)
       actionview (= 4.2.1)
       activesupport (= 4.2.1)
@@ -20,16 +14,6 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.1)
-    activejob (4.2.1)
-      activesupport (= 4.2.1)
-      globalid (>= 0.3.0)
-    activemodel (4.2.1)
-      activesupport (= 4.2.1)
-      builder (~> 3.1)
-    activerecord (4.2.1)
-      activemodel (= 4.2.1)
-      activesupport (= 4.2.1)
-      arel (~> 6.0)
     activesupport (4.2.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -38,7 +22,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
-    arel (6.0.0)
     builder (3.2.3)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
@@ -55,8 +38,6 @@ GEM
       multi_json (>= 1.7.5, < 2.0)
       nokogiri (~> 1.6.0)
       oauth2
-    globalid (0.3.5)
-      activesupport (>= 4.1.0)
     hashie (3.5.5)
     highline (1.7.8)
     i18n (0.7.0)
@@ -74,9 +55,6 @@ GEM
     jwt (1.5.6)
     loofah (2.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.6.3)
-      mime-types (>= 1.16, < 3)
-    mime-types (2.6.1)
     mini_portile2 (2.1.0)
     minitest (5.7.0)
     multi_json (1.12.1)
@@ -96,17 +74,6 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails (4.2.1)
-      actionmailer (= 4.2.1)
-      actionpack (= 4.2.1)
-      actionview (= 4.2.1)
-      activejob (= 4.2.1)
-      activemodel (= 4.2.1)
-      activerecord (= 4.2.1)
-      activesupport (= 4.2.1)
-      bundler (>= 1.3.0, < 2.0)
-      railties (= 4.2.1)
-      sprockets-rails
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.6)
@@ -115,11 +82,6 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
-    railties (4.2.1)
-      actionpack (= 4.2.1)
-      activesupport (= 4.2.1)
-      rake (>= 0.8.7)
-      thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
     rdoc (3.12.2)
       json (~> 1.4)
@@ -135,13 +97,6 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    sprockets (3.2.0)
-      rack (~> 1.0)
-    sprockets-rails (2.3.1)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (>= 2.8, < 4.0)
-    thor (0.19.1)
     thread_safe (0.3.6)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -150,12 +105,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionpack
   addressable
   bundler (~> 1.0)
   jeweler (~> 2.1.2)
   rack
   rack-proxy
-  rails
   rdoc (~> 3.12)
   shoulda
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,8 +70,6 @@ GEM
       rack (>= 1.2, < 3)
     public_suffix (2.0.5)
     rack (1.6.5)
-    rack-proxy (0.5.17)
-      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails-deprecated_sanitizer (1.0.3)
@@ -109,8 +107,6 @@ DEPENDENCIES
   addressable
   bundler (~> 1.0)
   jeweler (~> 2.1.2)
-  rack
-  rack-proxy
   rdoc (~> 3.12)
   shoulda
   simplecov

--- a/lib/reverse_proxy/client.rb
+++ b/lib/reverse_proxy/client.rb
@@ -1,5 +1,4 @@
 require 'rack'
-require 'rack-proxy'
 require 'addressable/uri'
 
 module ReverseProxy

--- a/rails-reverse-proxy.gemspec
+++ b/rails-reverse-proxy.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rails>.freeze, [">= 0"])
+      s.add_runtime_dependency(%q<actionpack>.freeze, [">= 0"])
       s.add_runtime_dependency(%q<rack>.freeze, [">= 0"])
       s.add_runtime_dependency(%q<rack-proxy>.freeze, [">= 0"])
       s.add_runtime_dependency(%q<addressable>.freeze, [">= 0"])
@@ -52,7 +52,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<jeweler>.freeze, ["~> 2.1.2"])
       s.add_development_dependency(%q<simplecov>.freeze, [">= 0"])
     else
-      s.add_dependency(%q<rails>.freeze, [">= 0"])
+      s.add_dependency(%q<actionpack>.freeze, [">= 0"])
       s.add_dependency(%q<rack>.freeze, [">= 0"])
       s.add_dependency(%q<rack-proxy>.freeze, [">= 0"])
       s.add_dependency(%q<addressable>.freeze, [">= 0"])
@@ -63,7 +63,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<simplecov>.freeze, [">= 0"])
     end
   else
-    s.add_dependency(%q<rails>.freeze, [">= 0"])
+    s.add_dependency(%q<actionpack>.freeze, [">= 0"])
     s.add_dependency(%q<rack>.freeze, [">= 0"])
     s.add_dependency(%q<rack-proxy>.freeze, [">= 0"])
     s.add_dependency(%q<addressable>.freeze, [">= 0"])
@@ -74,4 +74,3 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<simplecov>.freeze, [">= 0"])
   end
 end
-

--- a/rails-reverse-proxy.gemspec
+++ b/rails-reverse-proxy.gemspec
@@ -43,8 +43,6 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<actionpack>.freeze, [">= 0"])
-      s.add_runtime_dependency(%q<rack>.freeze, [">= 0"])
-      s.add_runtime_dependency(%q<rack-proxy>.freeze, [">= 0"])
       s.add_runtime_dependency(%q<addressable>.freeze, [">= 0"])
       s.add_development_dependency(%q<shoulda>.freeze, [">= 0"])
       s.add_development_dependency(%q<rdoc>.freeze, ["~> 3.12"])
@@ -53,8 +51,6 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<simplecov>.freeze, [">= 0"])
     else
       s.add_dependency(%q<actionpack>.freeze, [">= 0"])
-      s.add_dependency(%q<rack>.freeze, [">= 0"])
-      s.add_dependency(%q<rack-proxy>.freeze, [">= 0"])
       s.add_dependency(%q<addressable>.freeze, [">= 0"])
       s.add_dependency(%q<shoulda>.freeze, [">= 0"])
       s.add_dependency(%q<rdoc>.freeze, ["~> 3.12"])
@@ -64,8 +60,6 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<actionpack>.freeze, [">= 0"])
-    s.add_dependency(%q<rack>.freeze, [">= 0"])
-    s.add_dependency(%q<rack-proxy>.freeze, [">= 0"])
     s.add_dependency(%q<addressable>.freeze, [">= 0"])
     s.add_dependency(%q<shoulda>.freeze, [">= 0"])
     s.add_dependency(%q<rdoc>.freeze, ["~> 3.12"])


### PR DESCRIPTION
Apart from replacing the unnecessary heavy `rails` dependency with `actionpack`, I've also removed the unused `rack-proxy` dependency. `rack` is now no longer listed as an explicit dependency, but it is implicitly included over `actionpack`.

Not sure why this gem has a _Gemfile_.

As this gem has no test suite 😿  I bundled this updated version in our (closed source) app and ensured it still works as expected.

