### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ gem 'rails-reverse-proxy'
 Then (you guessed it!)
 
 ```
-$ bundle
+$ bundle install
 ```
 
 ## Usage


### PR DESCRIPTION
The bundle install section of the README.md is
```sh
bundle
```

if leaving it that way is intentional then you can overlook this PR, otherwise, we should make it explicit

```sh
bundle install
```