### PR TITLE
Fix requests defaulting to http

### DIFF
--- a/lib/reverse_proxy/client.rb
+++ b/lib/reverse_proxy/client.rb
@@ -85,7 +85,7 @@ module ReverseProxy
       http_options.merge!(options[:http]) if options[:http]
 
       # Make the request
-      Net::HTTP.start(uri.hostname, uri.port, http_options) do |http|
+      Net::HTTP.start(uri.hostname, uri.port || uri.default_port, http_options) do |http|
         callbacks[:on_connect].call(http)
         target_response = http.request(target_request)
       end


### PR DESCRIPTION
`Addressable::URI` behaves differently from `URI`:
```ruby
irb(main):016:0> Addressable::URI.parse('https://google.com').port
=> nil
irb(main):017:0> URI.parse('https://google.com').port
=> 443
irb(main):018:0> Addressable::URI.parse('https://google.com').default_port
=> 443
```