### PR TITLE
Fix DELETE requests

### DIFF
--- a/lib/reverse_proxy/client.rb
+++ b/lib/reverse_proxy/client.rb
@@ -65,9 +65,9 @@ module ReverseProxy
          && source_request.body
         source_request.body.rewind
         target_request.body_stream = source_request.body
+        target_request.content_length = source_request.content_length || 0
       end
 
-      target_request.content_length = source_request.content_length || 0
       target_request.content_type   = source_request.content_type if source_request.content_type
 
       # Hold the response here


### PR DESCRIPTION
I noticed that DELETE requests weren't properly proxied. They were simply timing out. The `content_length` is always set, even when the request doesn't accept a body. So this PR fixes this by setting the `content_length` only when a request body is permitted.