### PR TITLE
Choose Rack headers class depending on availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+ADDED:
+
+* **Rack 3 compatibility:** Use `Rack::Headers` if defined (i.e. if using Rack >= 3.0.0), otherwise use `Rack::Utils::HeaderHash`
+
 ## 0.11.0
 
 BUG FIXES:

--- a/lib/reverse_proxy/client.rb
+++ b/lib/reverse_proxy/client.rb
@@ -3,6 +3,15 @@ require 'addressable/uri'
 
 module ReverseProxy
   class Client
+    RackHeaders =
+      if Rack.const_defined?('Headers')
+        # Rack >= 3.0.0
+        Rack::Headers
+      else
+        # Rack < 3.0.0
+        Rack::Utils::HeaderHash
+      end
+
     @@callback_methods = [
       :on_response,
       :on_set_cookies,
@@ -132,7 +141,7 @@ module ReverseProxy
         !(/^HTTP_[A-Z_]+$/ === k) || k == "HTTP_VERSION" || v.nil?
       end.map do |k, v|
         [reconstruct_header_name(k), v]
-      end.inject(Rack::Utils::HeaderHash.new) do |hash, k_v|
+      end.inject(RackHeaders.new) do |hash, k_v|
         k, v = k_v
         hash[k] = v
         hash


### PR DESCRIPTION
closes #75 

Rack 3.0.0 deprecates Rack::Utils::HeaderHash, warns that the class will be removed in Rack 3.1, and suggests using Rack::Headers, instead. This change uses the Rack::Headers class, if it is defined (i.e. if rack >= 3.0.0 is installed), and otherwise falls back to using Rack::Utils::HeaderHash (i.e. for rack < 3.0.0).